### PR TITLE
Enhanced timetrace syntax definition

### DIFF
--- a/syntax/timetrace.sublime-syntax
+++ b/syntax/timetrace.sublime-syntax
@@ -4,15 +4,29 @@ file_extensions:
   - time
 scope: text.unifatimetrace
 name: UNIFA-Timetrace
+first_line_match: .*(callZFA_Call|doBind|doUnbd).*
 
 contexts:
   main:
-    # Column 1-6
-    - match: '(^.{4}\d)\ (\w+)\ +(\S{1,17})\ +(\d{2,4})\ ([0-9]{2}\.[0-9]{2}\.[0-9]{4}\ \-\-\-\ [0-9]{2}:[0-9]{2}:[0-9]{2})\ .+(ppid:\ .{4}\d)'
+    - match: '^(\d{5}) (\w+).*--- (\d{2}:\d{2}:\d{2}) --'
       captures:
-        1: comment.line.double-slash.unifatimetrace
-        2: constant.numeric.unifatimetrace
-        3: storage.type.unifatimetrace
-        4: comment.line.double-slash.unifatimetrace
-        5: string.unquoted.unifatimetrace
-        6: comment.line.double-slash.unifatimetrace
+        1: constant.numeric.unifatimetrace
+        2: entity.name.function.unifatimetrace
+        3: constant.numeric.unifatimetrace
+
+    - match: 'ppid: (\d+)'
+      captures:
+        1: constant.numeric.unifatimetrace
+
+    - match: '(\{ Vor|\} Nach)\s+(ZFA_Bind|ZFA_Unbind|ZFA_Call)\s+an\s+(.*)$'
+      captures:
+        1: invalid.illegal.invalid.illegal.unifatrace
+        2: invalid.illegal.invalid.illegal.unifatrace
+        3: entity.name.function.unifatimetrace
+
+    - match: '(\{|\}) (Enter|Leave) (\w+)'
+      captures:
+        1: comment.ufalistmsg
+        2: comment.ufalistmsg
+        3: comment.ufalistmsg
+


### PR DESCRIPTION
Timetrace syntax files no work with single-line as well as with multiline timetrace-files.

Enter, Leave, ZFA_Bind, ZFA_Unbind and ZFA_Call, pid and ppid are now highlighted instead of just numbers.
